### PR TITLE
Python 3.6 compatible

### DIFF
--- a/countries.py
+++ b/countries.py
@@ -43,7 +43,7 @@ class CountryChecker(object):
         Output is either country shape index or None
         """
         
-        for i in xrange(self.layer.GetFeatureCount()):
+        for i in range(self.layer.GetFeatureCount()):
             country = self.layer.GetFeature(i)
             if country.geometry().Contains(point.ogr):
                 return Country(country)


### PR DESCRIPTION
Changed call to "xrange" (l.46) by "range" so as to make the module compatible with Python 3.6.
Maybe this change can be integrated into the master repo or into a separate branch ?...